### PR TITLE
Removed docker containers after execution, Fixes Issue #29

### DIFF
--- a/src/docker.js
+++ b/src/docker.js
@@ -32,8 +32,8 @@ function checkExists() {
 
 function run(commands, image, dryRun, interactive, workDir) {
   const cmd = interactive
-    ? `run -P -it --entrypoint=/bin/bash -v ${pwd()}:${workDir} -w ${workDir} ${image}`
-    : `run  -P -v ${pwd()}:${workDir} -w ${workDir} ${image} sh ${BUILD_SCRIPT}`;
+    ? `run --rm -P -it --entrypoint=/bin/bash -v ${pwd()}:${workDir} -w ${workDir} ${image}`
+    : `run --rm -P -v ${pwd()}:${workDir} -w ${workDir} ${image} sh ${BUILD_SCRIPT}`;
 
   if (dryRun) {
     console.log(`docker command:\n\tdocker ${cmd}`);


### PR DESCRIPTION
This patch adds `--rm` parameter to `docker run` to automatically remove containers after execution. Could help to avoid docker containers adding up and using disk space.