### PR TITLE
Added ignore-folder argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Check the [examples](https://github.com/mserranom/bbrun/tree/master/examples) an
       --env (-e),  define environment variables for execution
       --dry-run (-d),  performs dry run, printing the docker command
       --interactive (-i), starts an interactive bash session in the container
+      --ignore-folder (-f), adds the folder as an empty volume (useful for forcing pipeline to install packages etc)
       --help, prints this very guide
 
   Examples:

--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ Examples:
       "dry-run": {
         type: "boolean",
         alias: "d"
+      },
+      "ignore-folders": {
+        type: "string",
+        alias: "if"
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ Examples:
       },
       "ignore-folder": {
         type: "string",
-        alias: "if"
+        alias: "f"
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ Options
     --work-dir (-w), docker working directory, defaults to "ws"
     --dry-run (-d), performs dry run, printing the docker command
     --interactive (-i), starts an interactive bash session in the container
+    --ignore-folder (-if), maps the folder to an empty folder (useful for forcing package managers to reinstall)
     --help, prints this very guide
 
 Examples:
@@ -58,7 +59,7 @@ Examples:
         type: "boolean",
         alias: "d"
       },
-      "ignore-folders": {
+      "ignore-folder": {
         type: "string",
         alias: "if"
       }

--- a/src/docker.js
+++ b/src/docker.js
@@ -30,10 +30,17 @@ function checkExists() {
   }
 }
 
-function run(commands, image, dryRun, interactive, workDir) {
+function run(commands, image, dryRun, interactive, workDir, ignoreFolders) {
+  if (typeof ignoreFolders === "string") {
+    ignoreFolders = [ignoreFolders];
+  }
+  const ignore = ignoreFolders.map((f) => {
+    return `-v ${pwd()}/empty/:${workDir}/${f}`;
+  }).join(' ');
+
   const cmd = interactive
-    ? `run --rm -P -it --entrypoint=/bin/bash -v ${pwd()}:${workDir} -w ${workDir} ${image}`
-    : `run --rm -P -v ${pwd()}:${workDir} -w ${workDir} ${image} bash ${BUILD_SCRIPT}`;
+    ? `run --rm -P -it --entrypoint=/bin/bash -v ${pwd()}:${workDir} ${ignore} -w ${workDir} ${image}`
+    : `run --rm -P -v ${pwd()}:${workDir} ${ignore} -w ${workDir} ${image} bash ${BUILD_SCRIPT}`;
 
   if (dryRun) {
     console.log(`docker command:\n\tdocker ${cmd}`);

--- a/src/docker.js
+++ b/src/docker.js
@@ -3,12 +3,19 @@ const exec = require("shelljs").exec;
 const pwd = require("shelljs").pwd;
 const fs = require("fs");
 const child_process = require("child_process");
+const path = require('path');
+const os = require('os');
 
 const BUILD_SCRIPT = ".bbrun.sh";
+const TMP_DIR = '.bbrun';
 
 function deleteBuildScript() {
   if (fs.existsSync(BUILD_SCRIPT)) {
     fs.unlinkSync(BUILD_SCRIPT);
+  }
+
+  if (fs.existsSync(`./${TMP_DIR}`)) {
+    deleteFolderSync(`./${TMP_DIR}`);
   }
 }
 
@@ -31,12 +38,15 @@ function checkExists() {
 }
 
 function run(commands, image, dryRun, interactive, workDir, ignoreFolder) {
-  if (typeof ignoreFolder === "string") {
-    ignoreFolder = [ignoreFolder];
+  let ignore = '';
+  if (typeof ignoreFolder !== "undefined") {
+    if (typeof ignoreFolder === "string") {
+      ignoreFolder = [ignoreFolder];
+    }
+    ignore = ignoreFolder.map((f) => {
+      return `-v ${pwd()}/${TMP_DIR}/:${workDir}/${f}`;
+    }).join(' ');
   }
-  const ignore = ignoreFolder.map((f) => {
-    return `-v ${pwd()}/empty/:${workDir}/${f}`;
-  }).join(' ');
 
   const cmd = interactive
     ? `run --rm -P -it --entrypoint=/bin/bash -v ${pwd()}:${workDir} ${ignore} -w ${workDir} ${image}`
@@ -65,6 +75,22 @@ function extractImageName(image) {
   } else {
     throw new Error(`"${JSON.stringify(image)}" is not a valid image`);
   }
+}
+
+function deleteFolderSync(path) {
+    var files = [];
+    if( fs.existsSync(path) ) {
+        files = fs.readdirSync(path);
+        files.forEach(function(file,index){
+            var curPath = path + "/" + file;
+            if(fs.lstatSync(curPath).isDirectory()) { // recurse
+                deleteFolderSync(curPath);
+            } else { // delete file
+                fs.unlinkSync(curPath);
+            }
+        });
+        fs.rmdirSync(path);
+    }
 }
 
 module.exports.checkExists = checkExists;

--- a/src/docker.js
+++ b/src/docker.js
@@ -30,11 +30,11 @@ function checkExists() {
   }
 }
 
-function run(commands, image, dryRun, interactive, workDir, ignoreFolders) {
-  if (typeof ignoreFolders === "string") {
-    ignoreFolders = [ignoreFolders];
+function run(commands, image, dryRun, interactive, workDir, ignoreFolder) {
+  if (typeof ignoreFolder === "string") {
+    ignoreFolder = [ignoreFolder];
   }
-  const ignore = ignoreFolders.map((f) => {
+  const ignore = ignoreFolder.map((f) => {
     return `-v ${pwd()}/empty/:${workDir}/${f}`;
   }).join(' ');
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -8,7 +8,7 @@ function exec(script, image, flags) {
     "set -e",
     script
   );
-  docker.run(commands, image, flags.dryRun, flags.interactive, flags.workDir);
+  docker.run(commands, image, flags.dryRun, flags.interactive, flags.workDir, flags.ignoreFolders);
 }
 
 module.exports.exec = exec;

--- a/src/exec.js
+++ b/src/exec.js
@@ -8,7 +8,7 @@ function exec(script, image, flags) {
     "set -e",
     script
   );
-  docker.run(commands, image, flags.dryRun, flags.interactive, flags.workDir, flags.ignoreFolders);
+  docker.run(commands, image, flags.dryRun, flags.interactive, flags.workDir, flags.ignoreFolder);
 }
 
 module.exports.exec = exec;


### PR DESCRIPTION
I ran into a use case for ignoring folders in the working dir, when I needed to make sure composer would install packages inside the docker container, instead of relying on the ones I already installed during development.

For my specific project I would add `--ignore-folder vendor` (composer files), but should work with node_modules etc.

Let me know if any other edits are needed :)