### PR TITLE
Fix issue #67

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -17,10 +17,10 @@ function extractPipelineName(pipeline) {
 }
 
 function parseVars(envArg) {
-  return envArg
-    .trim()
-    .split(",")
-    .map(x => x.trim());
+  // @see https://stackoverflow.com/questions/67978415/complex-assignments-with-comma-separator
+  return envArg.match(/(?=\b[a-z])\w+=(?:(['"])(?:(?!\1).)*\1|[^,]*)/gi);
+  // Alternative:
+  // return envArg.split(/,\s*(?=[A-Z]+=)/).map(x => x.trim())
 }
 
 module.exports.extractPipelineName = extractPipelineName;

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,4 +1,5 @@
-const { extractPipelineName } = require("../src/util");
+const {extractPipelineName} = require("../src/util");
+const {parseVars} = require("../src/util");
 
 describe("extractPipelineName", () => {
   it("general case", () => {
@@ -20,5 +21,65 @@ describe("extractPipelineName", () => {
       pipeline: "foo",
       pipelineName: "bar:bar"
     });
+  });
+});
+describe("parseVars function", () => {
+  it("should be one simple variable", () => {
+    expect(parseVars("ONE=one")).toMatchObject([
+      "ONE=one"
+    ]);
+  });
+  it("should be two simple variable", () => {
+    expect(parseVars("ONE=one,TWO=two")).toMatchObject([
+      "ONE=one",
+      "TWO=two"
+    ]);
+  });
+  it("should be two simple variable (Trim space)", () => {
+    expect(parseVars("ONE=one, TWO=two")).toMatchObject([
+      "ONE=one",
+      "TWO=two"
+    ]);
+  });
+  it("should be simple json", () => {
+    expect(parseVars("ONE='{}'")).toMatchObject([
+      "ONE='{}'",
+    ]);
+  });
+  it("should be three simple json", () => {
+    expect(parseVars("ONE='{}',TWO='{}',THREE='{}'")).toMatchObject([
+      "ONE='{}'",
+      "TWO='{}'",
+      "THREE='{}'",
+    ]);
+  });
+  it("should be three simple json (Simple quote)", () => {
+    expect(parseVars("ONE='{}'")).toMatchObject([
+      "ONE='{}'",
+    ]);
+  });
+  it("should be three simple json with attribute", () => {
+    expect(parseVars("ONE='{attr: \"value\"}'")).toMatchObject([
+      "ONE='{attr: \"value\"}'",
+    ]);
+  });
+  it("should be complex json with multiple attributes", () => {
+    expect(parseVars("ONE='{attr1: \"value\", attr2:\"value attr 2\"}'")).toMatchObject([
+      "ONE='{attr1: \"value\", attr2:\"value attr 2\"}'",
+    ]);
+  });
+
+  it("should be one json and one simple var", () => {
+    expect(parseVars("ONE='{}', TWO=two")).toMatchObject([
+      "ONE='{}'",
+      "TWO=two",
+    ]);
+  });
+  it("should be one json and two simple vars", () => {
+    expect(parseVars("ONE='{}', TWO=two, THREE=three")).toMatchObject([
+      "ONE='{}'",
+      "TWO=two",
+      "THREE=three",
+    ]);
   });
 });


### PR DESCRIPTION
Add fix and unit tests for issue #67. This PR admit cases like:

```
--env="AUTH='{"http-basic": {...}, "github-oauth": ... }', ENV=prod"
```

To be able to get two env vars: $AUTH and $ENV